### PR TITLE
Fix router view rendering output

### DIFF
--- a/app/Core/Router/Router.php
+++ b/app/Core/Router/Router.php
@@ -35,7 +35,10 @@ class Router
     }
 
     if (is_callable($handler)) {
-      echo call_user_func($handler);
+      $result = call_user_func($handler);
+      if (is_string($result)) {
+        echo $result;
+      }
       return;
     }
     http_response_code(404);


### PR DESCRIPTION
## Summary
- avoid stray digits after rendering views by not unconditionally echoing router handler output

## Testing
- `php -l app/Core/Router/Router.php`
- `php -r '$_SERVER["REQUEST_URI"]="/login"; $_SERVER["REQUEST_METHOD"]="GET"; $_SERVER["SCRIPT_NAME"]="/index.php"; require "index.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68ad01496578832dabbccb484f3eac65